### PR TITLE
Make CMake3.5 the minimum version

### DIFF
--- a/cmake/Hipify.cmake
+++ b/cmake/Hipify.cmake
@@ -1,6 +1,6 @@
 # cmake file to trigger hipify
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 set(HIPIFY_DICT_FILE ${CMAKE_BINARY_DIR}/hipify_output_dict_dump.txt)
 set(_temp_file_cuda_to_hip_list "cuda_to_hip_list")


### PR DESCRIPTION
CMake4.0 requires subprojects to require CMake3.5 at a minimum: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
```
Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to cmake_minimum_required(VERSION) or cmake_policy(VERSION) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce an error in CMake 4.0 and above.
```

Required for fbgemm_hip to build successfully after PyTorch updates for CMake4.0.
Related PyTorch PR: https://github.com/pytorch/pytorch/pull/150203